### PR TITLE
Update fil.php

### DIFF
--- a/src/dict/fil.php
+++ b/src/dict/fil.php
@@ -24,4 +24,12 @@ return [
     'hipon',
     'engot',
     'bruha',
+    'puta',
+    'kantot',
+    'yawa',
+    'piste',
+    'bayot',
+    'pakyu',
+    'supot',
+    'tang ina'
 ];


### PR DESCRIPTION
added a few words.

yawa ('the devil'), piste ('annoying'), and bayot ('gay') are not exactly Filipino words but are commonly used in Filipino profane sentences.

puta means prostitute. Derived from the Spanish word.

kantot is a vulgar word for sex

pakyu is 'fuck you' in Filipino accent

supot means uncircumcised. Usually means the person is a 'weakling'.

tang ina is just a shorter way of saying "putang ina"